### PR TITLE
Added convenience initializer that adds ability to hide library picker

### DIFF
--- a/ALCameraViewController/ViewController/ALCameraViewController.swift
+++ b/ALCameraViewController/ViewController/ALCameraViewController.swift
@@ -82,6 +82,12 @@ public class ALCameraViewController: UIViewController {
         commonInit()
     }
     
+    convenience public init(croppingEnabled: Bool, completion: ALCameraViewCompletion, allowsLibraryAccess: Bool) {
+        self.init(croppingEnabled: croppingEnabled, completion: completion)
+        self.libraryButton.enabled = allowsLibraryAccess
+        self.libraryButton.hidden = !allowsLibraryAccess
+    }
+    
     public override func prefersStatusBarHidden() -> Bool {
         return true
     }


### PR DESCRIPTION
I decided to make the initializer a convenience one, as it doesn't really do anything different than `init(croppingEnabled: Bool, completion: ALCameraViewCompletion)`, in terms of initialization. The convenience initializer simply calls that one and sets the library button to be both disabled and hidden.