### PR TITLE
Removed the cameraQueue due to race condition and redundant reloadData

### DIFF
--- a/ALCameraViewController/ViewController/ALImagePickerViewController.swift
+++ b/ALCameraViewController/ViewController/ALImagePickerViewController.swift
@@ -126,9 +126,5 @@ internal class ALImagePickerViewController: UIViewController {
         collectionView.registerClass(ALImageCell.self, forCellWithReuseIdentifier: ImageCellIdentifier)
         collectionView.delegate = collectionViewDelegate
         collectionView.dataSource = collectionViewDelegate
-        
-        dispatch_after(1, dispatch_get_main_queue()) {
-            self.collectionView.reloadData()
-        }
     }
 }

--- a/ALCameraViewController/Views/ALCameraView.swift
+++ b/ALCameraViewController/Views/ALCameraView.swift
@@ -17,29 +17,23 @@ public class ALCameraView: UIView {
     var imageOutput: AVCaptureStillImageOutput!
     var preview: AVCaptureVideoPreviewLayer!
     
-    let cameraQueue = dispatch_queue_create("com.zero.ALCameraViewController.Queue", DISPATCH_QUEUE_SERIAL);
     
     public var currentPosition = AVCaptureDevicePosition.Back
     
     public func startSession() {
         createPreview()
-        
-        dispatch_async(cameraQueue) {
-            self.session.startRunning()
-        }
+        session.startRunning()
     }
     
     public func stopSession() {
-        dispatch_async(cameraQueue) {
-            self.session?.stopRunning()
-            self.preview?.removeFromSuperlayer()
-            
-            self.session = nil
-            self.input = nil
-            self.imageOutput = nil
-            self.preview = nil
-            self.device = nil
-        }
+        session?.stopRunning()
+        preview?.removeFromSuperlayer()
+      
+        session = nil
+        input = nil
+        imageOutput = nil
+        preview = nil
+        device = nil
     }
     
     public override func layoutSubviews() {
@@ -95,18 +89,16 @@ public class ALCameraView: UIView {
     }
     
     public func capturePhoto(completion: ALCameraShotCompletion) {
-        dispatch_async(cameraQueue) {
-            let orientation = AVCaptureVideoOrientation(rawValue: UIDevice.currentDevice().orientation.rawValue)!
-            ALCameraShot().takePhoto(self.imageOutput, videoOrientation: orientation, cropSize: self.frame.size) { image in
-                
-                var correctedImage = image
-                
-                if self.currentPosition == .Front {
-                    correctedImage = image.fixFrontCameraOrientation()
-                }
-                
-                completion(correctedImage)
-            }
+        let orientation = AVCaptureVideoOrientation(rawValue: UIDevice.currentDevice().orientation.rawValue)!
+        ALCameraShot().takePhoto(self.imageOutput, videoOrientation: orientation, cropSize: self.frame.size) { image in
+        
+          var correctedImage = image
+        
+          if self.currentPosition == .Front {
+            correctedImage = image.fixFrontCameraOrientation()
+          }
+        
+          completion(correctedImage)
         }
     }
 

--- a/ALCameraViewController/Views/ALCameraView.swift
+++ b/ALCameraViewController/Views/ALCameraView.swift
@@ -10,122 +10,133 @@ import UIKit
 import AVFoundation
 
 public class ALCameraView: UIView {
-    
-    var session: AVCaptureSession!
-    var input: AVCaptureDeviceInput!
-    var device: AVCaptureDevice!
-    var imageOutput: AVCaptureStillImageOutput!
-    var preview: AVCaptureVideoPreviewLayer!
-    
-    
-    public var currentPosition = AVCaptureDevicePosition.Back
-    
-    public func startSession() {
-        createPreview()
-        session.startRunning()
+  
+  var session: AVCaptureSession!
+  var input: AVCaptureDeviceInput!
+  var device: AVCaptureDevice!
+  var imageOutput: AVCaptureStillImageOutput!
+  var preview: AVCaptureVideoPreviewLayer!
+  
+  let cameraQueue = dispatch_queue_create("com.zero.ALCameraViewController.Queue", DISPATCH_QUEUE_SERIAL);
+  
+  public var currentPosition = AVCaptureDevicePosition.Back
+  
+  public func startSession() {
+    dispatch_async(cameraQueue) {
+      self.createPreview()
+      self.session.startRunning()
     }
-    
-    public func stopSession() {
-        session?.stopRunning()
-        preview?.removeFromSuperlayer()
+  }
+  
+  public func stopSession() {
+    dispatch_async(cameraQueue) {
+      self.session?.stopRunning()
+      self.preview?.removeFromSuperlayer()
       
-        session = nil
-        input = nil
-        imageOutput = nil
-        preview = nil
-        device = nil
+      self.session = nil
+      self.input = nil
+      self.imageOutput = nil
+      self.preview = nil
+      self.device = nil
+    }
+  }
+  
+  public override func layoutSubviews() {
+    super.layoutSubviews()
+    if let p = preview {
+      p.frame = bounds
+    }
+  }
+  
+  private func createPreview() {
+    session = AVCaptureSession()
+    
+    dispatch_async(dispatch_get_main_queue()) {
+      
+      self.session.sessionPreset = AVCaptureSessionPresetHigh
+      
+      self.device = self.cameraWithPosition(self.currentPosition)
+      
+      let outputSettings = [AVVideoCodecKey:AVVideoCodecJPEG]
+      
+      do {
+        self.input = try AVCaptureDeviceInput(device: self.device)
+      } catch let error as NSError {
+        self.input = nil
+        print("Error: \(error.localizedDescription)")
+        return
+      }
+      
+      if self.session.canAddInput(self.input) {
+        self.session.addInput(self.input)
+      }
+      
+      self.imageOutput = AVCaptureStillImageOutput()
+      self.imageOutput.outputSettings = outputSettings
+      
+      self.session.addOutput(self.imageOutput)
+      
+      self.preview = AVCaptureVideoPreviewLayer(session: self.session)
+      self.preview.videoGravity = AVLayerVideoGravityResizeAspectFill
+      self.preview.frame = self.bounds
+      
+      self.layer.addSublayer(self.preview)
+    }
+  }
+  
+  private func cameraWithPosition(position: AVCaptureDevicePosition) -> AVCaptureDevice? {
+    let devices = AVCaptureDevice.devicesWithMediaType(AVMediaTypeVideo)
+    var _device: AVCaptureDevice?
+    for d in devices {
+      if d.position == position {
+        _device = d as? AVCaptureDevice
+        break
+      }
     }
     
-    public override func layoutSubviews() {
-        super.layoutSubviews()
-        if let p = preview {
-            p.frame = bounds
-        }
-    }
-    
-    private func createPreview() {
-        session = AVCaptureSession()
-        session.sessionPreset = AVCaptureSessionPresetHigh
+    return _device
+  }
+  
+  public func capturePhoto(completion: ALCameraShotCompletion) {
+    dispatch_async(cameraQueue) {
+      let orientation = AVCaptureVideoOrientation(rawValue: UIDevice.currentDevice().orientation.rawValue)!
+      ALCameraShot().takePhoto(self.imageOutput, videoOrientation: orientation, cropSize: self.frame.size) { image in
         
+        var correctedImage = image
+        
+        if self.currentPosition == .Front {
+          correctedImage = image.fixFrontCameraOrientation()
+        }
+        
+        completion(correctedImage)
+      }
+    }
+  }
+  
+  public func swapCameraInput() {
+    if session != nil && input != nil {
+      session.beginConfiguration()
+      session.removeInput(input)
+      
+      if input.device.position == AVCaptureDevicePosition.Back {
+        currentPosition = AVCaptureDevicePosition.Front
         device = cameraWithPosition(currentPosition)
-        
-        let outputSettings = [AVVideoCodecKey:AVVideoCodecJPEG]
-        
-        do {
-            input = try AVCaptureDeviceInput(device: device)
-        } catch let error as NSError {
-            input = nil
-            print("Error: \(error.localizedDescription)")
-            return
-        }
-        
-        if session.canAddInput(input) {
-            session.addInput(input)
-        }
-        
-        imageOutput = AVCaptureStillImageOutput()
-        imageOutput.outputSettings = outputSettings
-        
-        session.addOutput(imageOutput)
-        
-        preview = AVCaptureVideoPreviewLayer(session: session)
-        preview.videoGravity = AVLayerVideoGravityResizeAspectFill
-        preview.frame = bounds
-        
-        layer.addSublayer(preview)
+      } else {
+        currentPosition = AVCaptureDevicePosition.Back
+        device = cameraWithPosition(currentPosition)
+      }
+      
+      let error = NSErrorPointer()
+      do {
+        input = try AVCaptureDeviceInput(device: device)
+      } catch let error1 as NSError {
+        error.memory = error1
+        input = nil
+      }
+      
+      session.addInput(input)
+      session.commitConfiguration()
     }
-    
-    private func cameraWithPosition(position: AVCaptureDevicePosition) -> AVCaptureDevice? {
-        let devices = AVCaptureDevice.devicesWithMediaType(AVMediaTypeVideo)
-        var _device: AVCaptureDevice?
-        for d in devices {
-            if d.position == position {
-                _device = d as? AVCaptureDevice
-                break
-            }
-        }
-        
-        return _device
-    }
-    
-    public func capturePhoto(completion: ALCameraShotCompletion) {
-        let orientation = AVCaptureVideoOrientation(rawValue: UIDevice.currentDevice().orientation.rawValue)!
-        ALCameraShot().takePhoto(self.imageOutput, videoOrientation: orientation, cropSize: self.frame.size) { image in
-        
-          var correctedImage = image
-        
-          if self.currentPosition == .Front {
-            correctedImage = image.fixFrontCameraOrientation()
-          }
-        
-          completion(correctedImage)
-        }
-    }
-
-    public func swapCameraInput() {
-        if session != nil && input != nil {
-            session.beginConfiguration()
-            session.removeInput(input)
-            
-            if input.device.position == AVCaptureDevicePosition.Back {
-                currentPosition = AVCaptureDevicePosition.Front
-                device = cameraWithPosition(currentPosition)
-            } else {
-                currentPosition = AVCaptureDevicePosition.Back
-                device = cameraWithPosition(currentPosition)
-            }
-            
-            let error = NSErrorPointer()
-            do {
-                input = try AVCaptureDeviceInput(device: device)
-            } catch let error1 as NSError {
-                error.memory = error1
-                input = nil
-            }
-            
-            session.addInput(input)
-            session.commitConfiguration()
-        }
-    }
-
+  }
+  
 }


### PR DESCRIPTION
**Reload Data**

Removed the reloadData dispatch due it not being necessary as well as messing up the order of the images if you repeatedly go back in the image picker.

 In order to trigger this go into the image picker a few times and you will notice the thumbnails move around, if you select the image you will get the correct one. This seems to be triggered by the reloadData. 

It also appears unnecessary as the collectionView will build the cells when you designate the delegate and dataSource. 


**Camera Queue**

Removed the cameraQueue as it was creating a race condition and might cause the application to crash if you open the image picker and close it fast enough.

Since the createPreview() method is not on the queue, the stopSession method can be called in between the the createPreview method and session.startRunning(). This will cause session to invalidate and crash the application as session is nil.