### PR TITLE
Readme with renamed 'CameraViewController'

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In your viewController
 ```swift
 
 let croppingEnabled = true
-let cameraViewController = ALCameraViewController(croppingEnabled: croppingEnabled) { image in
+let cameraViewController = CameraViewController(croppingEnabled: croppingEnabled) { image in
 	// Do something with your image here. 
 	// If cropping is enabled this image will be the cropped version
 }


### PR DESCRIPTION
Just saw that the file is called "CameraViewController" now instead of "ALCameraViewController" and just wanted to fix the example code in the readme to match that!