### PR TITLE
Fix unsubscribing from notifications

### DIFF
--- a/ALCameraViewController/Utilities/VolumeControl.swift
+++ b/ALCameraViewController/Utilities/VolumeControl.swift
@@ -25,21 +25,16 @@ public class VolumeControl {
     var onVolumeChange: VolumeChangeAction?
     
     init(view: UIView, onVolumeChange: VolumeChangeAction?) {
-        
         self.onVolumeChange = onVolumeChange
         configureInView(view)
-        
-        do {
-            try AVAudioSession.sharedInstance().setActive(true)
-            NotificationCenter.default.addObserver(self, selector: #selector(volumeChanged), name: NSNotification.Name(rawValue: changeKey), object: nil)
-        } catch {
-        }
-        
 
+        try? AVAudioSession.sharedInstance().setActive(true)
+        NotificationCenter.default.addObserver(self, selector: #selector(volumeChanged),
+                                               name: NSNotification.Name(rawValue: changeKey), object: nil)
     }
     
     deinit {
-        try! AVAudioSession.sharedInstance().setActive(false)
+        try? AVAudioSession.sharedInstance().setActive(false)
         NotificationCenter.default.removeObserver(self)
         onVolumeChange = nil
         volumeView.removeFromSuperview()

--- a/ALCameraViewController/ViewController/CameraViewController.swift
+++ b/ALCameraViewController/ViewController/CameraViewController.swift
@@ -168,10 +168,6 @@ public class CameraViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-    
     public override var prefersStatusBarHidden: Bool {
         return true
     }
@@ -261,9 +257,6 @@ public class CameraViewController: UIViewController {
      */
     public override func viewDidLoad() {
         super.viewDidLoad()
-        addCameraObserver()
-        addRotateObserver()
-        setupVolumeControl()
         setupActions()
         checkPermissions()
         cameraView.configureFocus()
@@ -275,6 +268,19 @@ public class CameraViewController: UIViewController {
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         cameraView.startSession()
+        addCameraObserver()
+        addRotateObserver()
+        setupVolumeControl()
+    }
+
+    /**
+     * Unsubscribe from notifications
+     */
+
+    public override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        NotificationCenter.default.removeObserver(self)
+        volumeControl = nil
     }
     
     /**


### PR DESCRIPTION
After dismissing `CameraViewController` it still can react to volume changes either with physical buttons or after playing video (which shoots `AVSystemController_SystemVolumeDidChangeNotification`).

The problem can be solved by unsubscribing from notifications and nullifying `volumeControl` property in `viewWillDisappear` method of `CameraViewController`.

This pull-request does exactly that.