### PR TITLE
Add ability to localize all texts used in framework

### DIFF
--- a/ALCameraViewController/Utilities/Utilities.swift
+++ b/ALCameraViewController/Utilities/Utilities.swift
@@ -14,7 +14,13 @@ internal func radians(_ degrees: Double) -> Double {
 }
 
 internal func localizedString(_ key: String) -> String {
-    return NSLocalizedString(key, tableName: CameraGlobals.shared.stringsTable, bundle: CameraGlobals.shared.bundle, comment: key)
+    var bundle: Bundle {
+        if Bundle.main.path(forResource: CameraGlobals.shared.stringsTable, ofType: "strings") != nil {
+            return Bundle.main
+        }
+        return CameraGlobals.shared.bundle
+    }
+    return NSLocalizedString(key, tableName: CameraGlobals.shared.stringsTable, bundle: bundle, comment: key)
 }
 
 internal func currentRotation(_ oldOrientation: UIInterfaceOrientation, newOrientation: UIInterfaceOrientation) -> Double {


### PR DESCRIPTION
This pull-request is intended to add possibility to localize texts used in framework.

To use that feature one should add `CameraView.strings` file to the project and localize it as usual.

In case if such file is not provided in the main bundle all the texts fall back to original version.