### PR TITLE
Add ability to disable the camera orientation swap button

### DIFF
--- a/ALCameraViewController/ViewController/CameraViewController.swift
+++ b/ALCameraViewController/ViewController/CameraViewController.swift
@@ -156,15 +156,17 @@ open class CameraViewController: UIViewController {
         return view
     }()
   
-    public init(croppingEnabled: Bool, allowsLibraryAccess: Bool = true, completion: @escaping CameraViewCompletion) {
+	public init(croppingEnabled: Bool, allowsLibraryAccess: Bool = true, allowsSwapCameraOrientation: Bool = true, completion: @escaping CameraViewCompletion) {
         super.init(nibName: nil, bundle: nil)
         onCompletion = completion
         allowCropping = croppingEnabled
         cameraOverlay.isHidden = !allowCropping
         libraryButton.isEnabled = allowsLibraryAccess
         libraryButton.isHidden = !allowsLibraryAccess
+		swapButton.isEnabled = allowsSwapCameraOrientation
+		swapButton.isHidden = !allowsSwapCameraOrientation
     }
-  
+	
     required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/ALCameraViewController/ViewController/ConfirmViewController.swift
+++ b/ALCameraViewController/ViewController/ConfirmViewController.swift
@@ -346,9 +346,22 @@ extension UIImage {
 		rectTransform = rectTransform.scaledBy(x: scale, y: scale)
 		
 		if let cropped = cgImage?.cropping(to: rect.applying(rectTransform)) {
-			return UIImage(cgImage: cropped)
+			return UIImage(cgImage: cropped, scale: scale, orientation: imageOrientation).fixOrientation()
 		}
 		
 		return self
+	}
+	
+	func fixOrientation() -> UIImage {
+		if self.imageOrientation == UIImageOrientation.up {
+			return self
+		}
+		
+		UIGraphicsBeginImageContextWithOptions(self.size, false, self.scale)
+		self.draw(in: CGRect(x: 0, y: 0, width: self.size.width, height: self.size.height))
+		let normalizedImage: UIImage = UIGraphicsGetImageFromCurrentImageContext() ?? self
+		UIGraphicsEndImageContext()
+		
+		return normalizedImage
 	}
 }

--- a/ALCameraViewController/ViewController/ConfirmViewController.swift
+++ b/ALCameraViewController/ViewController/ConfirmViewController.swift
@@ -258,14 +258,27 @@ public class ConfirmViewController: UIViewController, UIScrollViewDelegate {
 				let normalizedHeight = cropRect.height / imageView.frame.height
 				
 				
-				let normRect = normalizedRect(CGRect(x: normalizedX, y: normalizedY, width: normalizedWidth, height: normalizedHeight), orientation: imageView.image!.imageOrientation)
+				var normRect = normalizedRect(CGRect(x: normalizedX, y: normalizedY, width: normalizedWidth, height: normalizedHeight), orientation: imageView.image!.imageOrientation)
 				print("NormRect: \(normRect)")
 				
-				let newRect = CGRect(x: (imageView.image!.size.width) * (1 - (normRect.origin.y + normRect.height)),
-				                     y: (imageView.image!.size.height) * normRect.origin.x,
-				                     width: (imageView.image!.size.width * normRect.height),
-				                     height: (imageView.image!.size.height * normRect.width))
-				// Note: Mixing x with height and y with width and flipping y because our image orientation is off by 90 degrees because the iPad's in portrait. In landscape, this fails miserably.
+				switch imageView.image!.imageOrientation {
+				case .left:
+					normRect = CGRect(x: normRect.origin.y, y: 1 - (normRect.origin.x + normRect.width), width: normRect.height, height: normRect.width)
+				case .right:
+					normRect = CGRect(x: 1 - (normRect.origin.y + normRect.height), y: normRect.origin.x, width: normRect.height, height: normRect.width)
+				case .up:
+					normRect = CGRect(x: normRect.origin.x, y: normRect.origin.y, width: normRect.width, height: normRect.height)
+				case .down:
+					normRect = CGRect(x: 1 - (normRect.origin.x + normRect.width), y: 1 - (normRect.origin.y + normRect.height), width: normRect.width, height: normRect.height)
+				default:
+					normRect = CGRect(x: 1 - (normRect.origin.x + normRect.width), y: normRect.origin.y, width: normRect.width, height: normRect.height)
+				}
+				
+				let newRect = CGRect(x: (imageView.image!.size.width) * normRect.origin.x,
+				                     y: (imageView.image!.size.height) * normRect.origin.y,
+				                     width: (imageView.image!.size.width * normRect.width),
+				                     height: (imageView.image!.size.height * normRect.height))
+				
 				print("NewRect: \(newRect)")
 				newImage = imageView.image?.crop(rect: newRect)
 			}

--- a/ALCameraViewController/ViewController/ConfirmViewController.swift
+++ b/ALCameraViewController/ViewController/ConfirmViewController.swift
@@ -10,20 +10,20 @@ import UIKit
 import Photos
 
 public class ConfirmViewController: UIViewController, UIScrollViewDelegate {
-    
-    let imageView = UIImageView()
-    @IBOutlet weak var scrollView: UIScrollView!
-    @IBOutlet weak var cropOverlay: CropOverlay!
-    @IBOutlet weak var cancelButton: UIButton!
-    @IBOutlet weak var confirmButton: UIButton!
-    @IBOutlet weak var centeringView: UIView!
-    
-    var allowsCropping: Bool = false
-    var verticalPadding: CGFloat = 30
-    var horizontalPadding: CGFloat = 30
-    
-    public var onComplete: CameraViewCompletion?
-    
+	
+	let imageView = UIImageView()
+	@IBOutlet weak var scrollView: UIScrollView!
+	@IBOutlet weak var cropOverlay: CropOverlay!
+	@IBOutlet weak var cancelButton: UIButton!
+	@IBOutlet weak var confirmButton: UIButton!
+	@IBOutlet weak var centeringView: UIView!
+	
+	var allowsCropping: Bool = false
+	var verticalPadding: CGFloat = 30
+	var horizontalPadding: CGFloat = 30
+	
+	public var onComplete: CameraViewCompletion?
+	
 	let asset: PHAsset?
 	let image: UIImage?
 	
@@ -34,42 +34,42 @@ public class ConfirmViewController: UIViewController, UIScrollViewDelegate {
 		super.init(nibName: "ConfirmViewController", bundle: CameraGlobals.shared.bundle)
 	}
 	
-    public init(asset: PHAsset, allowsCropping: Bool) {
-        self.allowsCropping = allowsCropping
-        self.asset = asset
+	public init(asset: PHAsset, allowsCropping: Bool) {
+		self.allowsCropping = allowsCropping
+		self.asset = asset
 		self.image = nil
-        super.init(nibName: "ConfirmViewController", bundle: CameraGlobals.shared.bundle)
-    }
-    
-    public required init?(coder aDecoder: NSCoder) {
+		super.init(nibName: "ConfirmViewController", bundle: CameraGlobals.shared.bundle)
+	}
+	
+	public required init?(coder aDecoder: NSCoder) {
 		asset = nil
 		image = nil
-        super.init(coder: aDecoder)
-    }
-    
-    public override var prefersStatusBarHidden: Bool {
-        return true
-    }
-    
-    public override var preferredStatusBarUpdateAnimation: UIStatusBarAnimation {
-        return UIStatusBarAnimation.slide
-    }
-    
-    public override func viewDidLoad() {
-        super.viewDidLoad()
-
-        view.backgroundColor = UIColor.black
-        
-        scrollView.addSubview(imageView)
-        scrollView.delegate = self
-        scrollView.maximumZoomScale = 1
-        
-        cropOverlay.isHidden = true
-        
-        let spinner = showSpinner()
-        
-        disable()
-
+		super.init(coder: aDecoder)
+	}
+	
+	public override var prefersStatusBarHidden: Bool {
+		return true
+	}
+	
+	public override var preferredStatusBarUpdateAnimation: UIStatusBarAnimation {
+		return UIStatusBarAnimation.slide
+	}
+	
+	public override func viewDidLoad() {
+		super.viewDidLoad()
+		
+		view.backgroundColor = UIColor.black
+		
+		scrollView.addSubview(imageView)
+		scrollView.delegate = self
+		scrollView.maximumZoomScale = 1
+		
+		cropOverlay.isHidden = true
+		
+		let spinner = showSpinner()
+		
+		disable()
+		
 		if let asset = asset {
 			_ = SingleImageFetcher()
 				.setAsset(asset)
@@ -88,151 +88,153 @@ public class ConfirmViewController: UIViewController, UIScrollViewDelegate {
 			self.hideSpinner(spinner)
 			self.enable()
 		}
-    }
+	}
 	
-    public override func viewWillLayoutSubviews() {
-        super.viewWillLayoutSubviews()
-        let scale = calculateMinimumScale(view.frame.size)
-        let frame = allowsCropping ? cropOverlay.frame : view.bounds
-
-        scrollView.contentInset = calculateScrollViewInsets(frame)
-        scrollView.minimumZoomScale = scale
-        scrollView.zoomScale = scale
-        centerScrollViewContents()
-        centerImageViewOnRotate()
-    }
-    
-    public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
-        
-        let scale = calculateMinimumScale(size)
-        var frame = view.bounds
-        
-        if allowsCropping {
-            frame = cropOverlay.frame
-            let centeringFrame = centeringView.frame
-            var origin: CGPoint
-            
-            if size.width > size.height { // landscape
-                let offset = (size.width - centeringFrame.height)
-                let expectedX = (centeringFrame.height/2 - frame.height/2) + offset
-                origin = CGPoint(x: expectedX, y: frame.origin.x)
-            } else {
-                let expectedY = (centeringFrame.width/2 - frame.width/2)
-                origin = CGPoint(x: frame.origin.y, y: expectedY)
-            }
-            
-            frame.origin = origin
-        } else {
-            frame.size = size
-        }
-
-        let insets = calculateScrollViewInsets(frame)
-
-        coordinator.animate(alongsideTransition: { [weak self] context in
-            self?.scrollView.contentInset = insets
-            self?.scrollView.minimumZoomScale = scale
-            self?.scrollView.zoomScale = scale
-            self?.centerScrollViewContents()
-            self?.centerImageViewOnRotate()
-            }, completion: nil)
-    }
-    
-    private func configureWithImage(_ image: UIImage) {
-        if allowsCropping {
-            cropOverlay.isHidden = false
-        } else {
-            cropOverlay.isHidden = true
-        }
-        
-        buttonActions()
-        
-        imageView.image = image
-        imageView.sizeToFit()
-        view.setNeedsLayout()
-    }
-    
-    private func calculateMinimumScale(_ size: CGSize) -> CGFloat {
-        var _size = size
-        
-        if allowsCropping {
-            _size = cropOverlay.frame.size
-        }
-        
-        guard let image = imageView.image else {
-            return 1
-        }
-        
-        let scaleWidth = _size.width / image.size.width
-        let scaleHeight = _size.height / image.size.height
-        
-        var scale: CGFloat
-        
-        if allowsCropping {
-            scale = max(scaleWidth, scaleHeight)
-        } else {
-            scale = min(scaleWidth, scaleHeight)
-        }
-        
-        return scale
-    }
-    
-    private func calculateScrollViewInsets(_ frame: CGRect) -> UIEdgeInsets {
-        let bottom = view.frame.height - (frame.origin.y + frame.height)
-        let right = view.frame.width - (frame.origin.x + frame.width)
-        let insets = UIEdgeInsets(top: frame.origin.y, left: frame.origin.x, bottom: bottom, right: right)
-        return insets
-    }
-    
-    private func centerImageViewOnRotate() {
-        if allowsCropping {
-            let size = allowsCropping ? cropOverlay.frame.size : scrollView.frame.size
-            let scrollInsets = scrollView.contentInset
-            let imageSize = imageView.frame.size
-            var contentOffset = CGPoint(x: -scrollInsets.left, y: -scrollInsets.top)
-            contentOffset.x -= (size.width - imageSize.width) / 2
-            contentOffset.y -= (size.height - imageSize.height) / 2
-            scrollView.contentOffset = contentOffset
-        }
-    }
-    
-    private func centerScrollViewContents() {
-        let size = allowsCropping ? cropOverlay.frame.size : scrollView.frame.size
-        let imageSize = imageView.frame.size
-        var imageOrigin = CGPoint.zero
-        
-        if imageSize.width < size.width {
-            imageOrigin.x = (size.width - imageSize.width) / 2
-        }
-        
-        if imageSize.height < size.height {
-            imageOrigin.y = (size.height - imageSize.height) / 2
-        }
-        
-        imageView.frame.origin = imageOrigin
-    }
-    
-    private func buttonActions() {
-        confirmButton.action = { [weak self] in self?.confirmPhoto() }
-        cancelButton.action = { [weak self] in self?.cancel() }
-    }
-    
-    internal func cancel() {
-        onComplete?(nil, nil)
-    }
-    
-    internal func confirmPhoto() {
-        
-        disable()
-        
-        imageView.isHidden = true
-        
-        let spinner = showSpinner()
-
-		var fetcher: SingleImageFetcher? = nil
+	public override func viewWillLayoutSubviews() {
+		super.viewWillLayoutSubviews()
+		let scale = calculateMinimumScale(view.frame.size)
+		let frame = allowsCropping ? cropOverlay.frame : view.bounds
+		
+		scrollView.contentInset = calculateScrollViewInsets(frame)
+		scrollView.minimumZoomScale = scale
+		scrollView.zoomScale = scale
+		centerScrollViewContents()
+		centerImageViewOnRotate()
+	}
+	
+	public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+		super.viewWillTransition(to: size, with: coordinator)
+		
+		let scale = calculateMinimumScale(size)
+		var frame = view.bounds
+		
+		if allowsCropping {
+			frame = cropOverlay.frame
+			let centeringFrame = centeringView.frame
+			var origin: CGPoint
+			
+			if size.width > size.height { // landscape
+				let offset = (size.width - centeringFrame.height)
+				let expectedX = (centeringFrame.height/2 - frame.height/2) + offset
+				origin = CGPoint(x: expectedX, y: frame.origin.x)
+			} else {
+				let expectedY = (centeringFrame.width/2 - frame.width/2)
+				origin = CGPoint(x: frame.origin.y, y: expectedY)
+			}
+			
+			frame.origin = origin
+		} else {
+			frame.size = size
+		}
+		
+		let insets = calculateScrollViewInsets(frame)
+		
+		coordinator.animate(alongsideTransition: { [weak self] context in
+			self?.scrollView.contentInset = insets
+			self?.scrollView.minimumZoomScale = scale
+			self?.scrollView.zoomScale = scale
+			self?.centerScrollViewContents()
+			self?.centerImageViewOnRotate()
+			}, completion: nil)
+	}
+	
+	private func configureWithImage(_ image: UIImage) {
+		if allowsCropping {
+			cropOverlay.isHidden = false
+		} else {
+			cropOverlay.isHidden = true
+		}
+		
+		buttonActions()
+		
+		imageView.image = image
+		imageView.sizeToFit()
+		view.setNeedsLayout()
+	}
+	
+	private func calculateMinimumScale(_ size: CGSize) -> CGFloat {
+		var _size = size
+		
+		if allowsCropping {
+			_size = cropOverlay.frame.size
+		}
+		
+		guard let image = imageView.image else {
+			return 1
+		}
+		
+		let scaleWidth = _size.width / image.size.width
+		let scaleHeight = _size.height / image.size.height
+		
+		var scale: CGFloat
+		
+		if allowsCropping {
+			scale = max(scaleWidth, scaleHeight)
+		} else {
+			scale = min(scaleWidth, scaleHeight)
+		}
+		
+		return scale
+	}
+	
+	private func calculateScrollViewInsets(_ frame: CGRect) -> UIEdgeInsets {
+		let bottom = view.frame.height - (frame.origin.y + frame.height)
+		let right = view.frame.width - (frame.origin.x + frame.width)
+		let insets = UIEdgeInsets(top: frame.origin.y, left: frame.origin.x, bottom: bottom, right: right)
+		return insets
+	}
+	
+	private func centerImageViewOnRotate() {
+		if allowsCropping {
+			let size = allowsCropping ? cropOverlay.frame.size : scrollView.frame.size
+			let scrollInsets = scrollView.contentInset
+			let imageSize = imageView.frame.size
+			var contentOffset = CGPoint(x: -scrollInsets.left, y: -scrollInsets.top)
+			contentOffset.x -= (size.width - imageSize.width) / 2
+			contentOffset.y -= (size.height - imageSize.height) / 2
+			scrollView.contentOffset = contentOffset
+		}
+	}
+	
+	private func centerScrollViewContents() {
+		let size = allowsCropping ? cropOverlay.frame.size : scrollView.frame.size
+		let imageSize = imageView.frame.size
+		var imageOrigin = CGPoint.zero
+		
+		if imageSize.width < size.width {
+			imageOrigin.x = (size.width - imageSize.width) / 2
+		}
+		
+		if imageSize.height < size.height {
+			imageOrigin.y = (size.height - imageSize.height) / 2
+		}
+		
+		imageView.frame.origin = imageOrigin
+	}
+	
+	private func buttonActions() {
+		confirmButton.action = { [weak self] in self?.confirmPhoto() }
+		cancelButton.action = { [weak self] in self?.cancel() }
+	}
+	
+	internal func cancel() {
+		onComplete?(nil, nil)
+	}
+	
+	internal func confirmPhoto() {
+		
+		guard let image = imageView.image else {
+			return
+		}
+		
+		disable()
+		
+		imageView.isHidden = true
+		
+		let spinner = showSpinner()
 		
 		if let asset = asset {
-			fetcher = SingleImageFetcher()
+			var fetcher = SingleImageFetcher()
 				.onSuccess { [weak self] image in
 					self?.onComplete?(image, self?.asset)
 					self?.hideSpinner(spinner)
@@ -243,112 +245,85 @@ public class ConfirmViewController: UIViewController, UIScrollViewDelegate {
 					self?.showNoImageScreen(error)
 				}
 				.setAsset(asset)
+			if allowsCropping {
+				let rect = normalizedRect(makeProportionalCropRect(), orientation: image.imageOrientation)
+				fetcher = fetcher.setCropRect(rect)
+			}
+			
+			fetcher = fetcher.fetch()
 		} else {
 			var newImage = image
 			
 			if allowsCropping {
-				var cropRect = cropOverlay.frame
-				cropRect.origin.x += scrollView.contentOffset.x
-				cropRect.origin.y += scrollView.contentOffset.y
-				
-				let normalizedX = cropRect.origin.x / imageView.frame.width
-				let normalizedY = cropRect.origin.y / imageView.frame.height
-				
-				let normalizedWidth = cropRect.width / imageView.frame.width
-				let normalizedHeight = cropRect.height / imageView.frame.height
-				
-				
-				var normRect = normalizedRect(CGRect(x: normalizedX, y: normalizedY, width: normalizedWidth, height: normalizedHeight), orientation: imageView.image!.imageOrientation)
-				print("NormRect: \(normRect)")
-				
-				switch imageView.image!.imageOrientation {
-				case .left:
-					normRect = CGRect(x: normRect.origin.y, y: 1 - (normRect.origin.x + normRect.width), width: normRect.height, height: normRect.width)
-				case .right:
-					normRect = CGRect(x: 1 - (normRect.origin.y + normRect.height), y: normRect.origin.x, width: normRect.height, height: normRect.width)
-				case .up:
-					normRect = CGRect(x: normRect.origin.x, y: normRect.origin.y, width: normRect.width, height: normRect.height)
-				case .down:
-					normRect = CGRect(x: 1 - (normRect.origin.x + normRect.width), y: 1 - (normRect.origin.y + normRect.height), width: normRect.width, height: normRect.height)
-				default:
-					normRect = CGRect(x: 1 - (normRect.origin.x + normRect.width), y: normRect.origin.y, width: normRect.width, height: normRect.height)
-				}
-				
-				let newRect = CGRect(x: (imageView.image!.size.width) * normRect.origin.x,
-				                     y: (imageView.image!.size.height) * normRect.origin.y,
-				                     width: (imageView.image!.size.width * normRect.width),
-				                     height: (imageView.image!.size.height * normRect.height))
-				
-				print("NewRect: \(newRect)")
-				newImage = imageView.image?.crop(rect: newRect)
+				let cropRect = makeProportionalCropRect()
+				let resizedCropRect = CGRect(x: (image.size.width) * cropRect.origin.x,
+				                     y: (image.size.height) * cropRect.origin.y,
+				                     width: (image.size.width * cropRect.width),
+				                     height: (image.size.height * cropRect.height))
+				newImage = image.crop(rect: resizedCropRect)
 			}
 			
 			self.onComplete?(newImage, nil)
 			self.hideSpinner(spinner)
 			self.enable()
 		}
+	}
+	
+	public func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+		return imageView
+	}
+	
+	public func scrollViewDidZoom(_ scrollView: UIScrollView) {
+		centerScrollViewContents()
+	}
+	
+	func showSpinner() -> UIActivityIndicatorView {
+		let spinner = UIActivityIndicatorView()
+		spinner.activityIndicatorViewStyle = .white
+		spinner.center = view.center
+		spinner.startAnimating()
 		
-        if allowsCropping {
-			
-            var cropRect = cropOverlay.frame
-            cropRect.origin.x += scrollView.contentOffset.x
-            cropRect.origin.y += scrollView.contentOffset.y
-            
-            let normalizedX = cropRect.origin.x / imageView.frame.width
-            let normalizedY = cropRect.origin.y / imageView.frame.height
-            
-            let normalizedWidth = cropRect.width / imageView.frame.width
-            let normalizedHeight = cropRect.height / imageView.frame.height
-            
-            let rect = normalizedRect(CGRect(x: normalizedX, y: normalizedY, width: normalizedWidth, height: normalizedHeight), orientation: imageView.image!.imageOrientation)
-            
-            fetcher = fetcher?.setCropRect(rect)
-        }
-        
-        fetcher = fetcher?.fetch()
-    }
-    
-    public func viewForZooming(in scrollView: UIScrollView) -> UIView? {
-        return imageView
-    }
-    
-    public func scrollViewDidZoom(_ scrollView: UIScrollView) {
-        centerScrollViewContents()
-    }
-    
-    func showSpinner() -> UIActivityIndicatorView {
-        let spinner = UIActivityIndicatorView()
-        spinner.activityIndicatorViewStyle = .white
-        spinner.center = view.center
-        spinner.startAnimating()
-        
-        view.addSubview(spinner)
-        view.bringSubview(toFront: spinner)
-        
-        return spinner
-    }
-    
-    func hideSpinner(_ spinner: UIActivityIndicatorView) {
-        spinner.stopAnimating()
-        spinner.removeFromSuperview()
-    }
-    
-    func disable() {
-        confirmButton.isEnabled = false
-    }
-    
-    func enable() {
-        confirmButton.isEnabled = true
-    }
-    
-    func showNoImageScreen(_ error: NSError) {
-        let permissionsView = PermissionsView(frame: view.bounds)
-        
-        let desc = localizedString("error.cant-fetch-photo.description")
-        
-        permissionsView.configureInView(view, title: error.localizedDescription, description: desc, completion: { [weak self] in self?.cancel() })
-    }
-    
+		view.addSubview(spinner)
+		view.bringSubview(toFront: spinner)
+		
+		return spinner
+	}
+	
+	func hideSpinner(_ spinner: UIActivityIndicatorView) {
+		spinner.stopAnimating()
+		spinner.removeFromSuperview()
+	}
+	
+	func disable() {
+		confirmButton.isEnabled = false
+	}
+	
+	func enable() {
+		confirmButton.isEnabled = true
+	}
+	
+	func showNoImageScreen(_ error: NSError) {
+		let permissionsView = PermissionsView(frame: view.bounds)
+		
+		let desc = localizedString("error.cant-fetch-photo.description")
+		
+		permissionsView.configureInView(view, title: error.localizedDescription, description: desc, completion: { [weak self] in self?.cancel() })
+	}
+	
+	private func makeProportionalCropRect() -> CGRect {
+		var cropRect = cropOverlay.frame
+		cropRect.origin.x += scrollView.contentOffset.x
+		cropRect.origin.y += scrollView.contentOffset.y
+		
+		let normalizedX = cropRect.origin.x / imageView.frame.width
+		let normalizedY = cropRect.origin.y / imageView.frame.height
+		
+		let normalizedWidth = cropRect.width / imageView.frame.width
+		let normalizedHeight = cropRect.height / imageView.frame.height
+		
+		return CGRect(x: normalizedX, y: normalizedY, width: normalizedWidth, height: normalizedHeight)
+	}
+	
 }
 
 extension UIImage {
@@ -371,7 +346,7 @@ extension UIImage {
 		rectTransform = rectTransform.scaledBy(x: scale, y: scale)
 		
 		if let cropped = cgImage?.cropping(to: rect.applying(rectTransform)) {
-			return UIImage(cgImage: cropped, scale: scale, orientation: imageOrientation)
+			return UIImage(cgImage: cropped)
 		}
 		
 		return self


### PR DESCRIPTION
We're making a kiosk app and need it to only have a front-facing camera.