### PR TITLE
Added resizable cropping area feature

### DIFF
--- a/ALCameraViewController.xcodeproj/project.pbxproj
+++ b/ALCameraViewController.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7AC96FA21F5B5166003E53F4 /* CroppingParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC96FA11F5B5166003E53F4 /* CroppingParameters.swift */; };
 		C40665441C73A47C00EB9751 /* SingleImageSaver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40665431C73A47C00EB9751 /* SingleImageSaver.swift */; };
 		C40665461C73A94100EB9751 /* CameraGlobals.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40665451C73A94100EB9751 /* CameraGlobals.swift */; };
 		C40665481C73B72D00EB9751 /* SingleImageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40665471C73B72D00EB9751 /* SingleImageFetcher.swift */; };
@@ -58,6 +59,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		7AC96FA11F5B5166003E53F4 /* CroppingParameters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CroppingParameters.swift; sourceTree = "<group>"; };
 		C40665431C73A47C00EB9751 /* SingleImageSaver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SingleImageSaver.swift; sourceTree = "<group>"; };
 		C40665451C73A94100EB9751 /* CameraGlobals.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraGlobals.swift; sourceTree = "<group>"; };
 		C40665471C73B72D00EB9751 /* SingleImageFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SingleImageFetcher.swift; sourceTree = "<group>"; };
@@ -154,6 +156,7 @@
 				C4D9BA441CA7224B004F70F7 /* PhotoLibraryAuthorizer.swift */,
 				C4D9BA461CA73163004F70F7 /* UIButtonExtensions.swift */,
 				EBFE097C1CAF1D1A00A8C637 /* UIViewExtensions.swift */,
+				7AC96FA11F5B5166003E53F4 /* CroppingParameters.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -366,6 +369,7 @@
 				FAB50C001B413E8C009905B9 /* PhotoLibraryViewController.swift in Sources */,
 				FAF0586A1B317894008E5592 /* CameraShot.swift in Sources */,
 				FAF058661B316695008E5592 /* CameraViewController.swift in Sources */,
+				7AC96FA21F5B5166003E53F4 /* CroppingParameters.swift in Sources */,
 				C4D9BA451CA7224B004F70F7 /* PhotoLibraryAuthorizer.swift in Sources */,
 				FAB50BFB1B413E8C009905B9 /* ImageCell.swift in Sources */,
 				EBFE097D1CAF1D1A00A8C637 /* UIViewExtensions.swift in Sources */,

--- a/ALCameraViewController/Utilities/CroppingParameters.swift
+++ b/ALCameraViewController/Utilities/CroppingParameters.swift
@@ -1,0 +1,33 @@
+//
+//  CroppingParameters.swift
+//  ALCameraViewController
+//
+//  Created by Guillaume Bellut on 02/09/2017.
+//  Copyright © 2017 zero. All rights reserved.
+//
+
+import UIKit
+
+public struct CroppingParameters {
+
+    /// Enable the cropping feature.
+    /// Default value is set to false.
+    var isEnabled: Bool
+
+    /// Allow the cropping area to be resized by the user.
+    /// Default value is set to true.
+    var allowResizing: Bool
+
+    /// Prevent the user to resize the cropping area below a minimum size.
+    /// Default value is (60, 60). Below this value, corner buttons will overlap.
+    var minimumSize: CGSize
+
+    init(isEnabled: Bool = false,
+         allowResizing: Bool = true,
+         minimumSize: CGSize = CGSize(width: 60, height: 60)) {
+
+        self.isEnabled = isEnabled
+        self.allowResizing = allowResizing
+        self.minimumSize = minimumSize
+    }
+}

--- a/ALCameraViewController/Utilities/SingleImageFetcher.swift
+++ b/ALCameraViewController/Utilities/SingleImageFetcher.swift
@@ -78,12 +78,11 @@ public class SingleImageFetcher {
             options.resizeMode = .exact
             
             let targetWidth = floor(CGFloat(asset.pixelWidth) * cropRect.width)
-            let targetHeight = floor(CGFloat(asset.pixelHeight) * cropRect.height)
-            let dimension = max(min(targetHeight, targetWidth), 1024 * scale)
-            
-            targetSize = CGSize(width: dimension, height: dimension)
+			let targetHeight = floor(CGFloat(asset.pixelHeight) * cropRect.height)
+			
+			targetSize = CGSize(width: targetWidth, height: targetHeight)
         }
-        
+		
         PHImageManager.default().requestImage(for: asset, targetSize: targetSize, contentMode: .aspectFill, options: options) { image, _ in
             if let image = image {
                 self.success?(image)

--- a/ALCameraViewController/ViewController/ConfirmViewController.xib
+++ b/ALCameraViewController/ViewController/ConfirmViewController.xib
@@ -1,8 +1,13 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_0" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ConfirmViewController" customModule="ALCameraViewController" customModuleProvider="target">
@@ -17,47 +22,41 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oUR-U3-uEM">
-                    <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
-                    <variation key="heightClass=compact" ambiguous="YES">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="400"/>
-                    </variation>
-                    <variation key="heightClass=compact-widthClass=regular" ambiguous="YES">
-                        <rect key="frame" x="0.0" y="0.0" width="800" height="400"/>
-                    </variation>
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                 </scrollView>
-                <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ASf-ZD-cIs">
-                    <rect key="frame" x="224" y="526" width="44" height="44"/>
+                <view hidden="YES" userInteractionEnabled="NO" alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KYd-D9-K5d">
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="474"/>
+                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lnA-tb-Sap" customClass="CropOverlay" customModule="ALCameraViewController" customModuleProvider="target">
+                    <rect key="frame" x="15" y="92" width="290" height="290"/>
+                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="width" secondItem="lnA-tb-Sap" secondAttribute="height" multiplier="1:1" id="lv8-l9-lJq"/>
+                    </constraints>
+                </view>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ASf-ZD-cIs">
+                    <rect key="frame" x="74" y="474" width="64" height="64"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="64" id="J7n-mn-Ebe"/>
                         <constraint firstAttribute="width" constant="64" id="YWt-e6-Bvy"/>
                     </constraints>
                     <state key="normal" image="confirmButton"/>
                 </button>
-                <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yRi-ES-LfN">
-                    <rect key="frame" x="328" y="526" width="44" height="44"/>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yRi-ES-LfN">
+                    <rect key="frame" x="198" y="474" width="64" height="64"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="64" id="FdJ-mW-Tx6"/>
                         <constraint firstAttribute="width" constant="64" id="urS-JS-i1S"/>
                     </constraints>
                     <state key="normal" image="retakeButton"/>
                 </button>
-                <view hidden="YES" userInteractionEnabled="NO" alpha="0.0" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KYd-D9-K5d">
-                    <rect key="frame" x="0.0" y="0.0" width="240" height="128"/>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                </view>
-                <view contentMode="scaleToFill" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lnA-tb-Sap" customClass="CropOverlay" customModule="ALCameraViewController" customModuleProvider="target">
-                    <rect key="frame" x="0.0" y="0.0" width="240" height="128"/>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                    <constraints>
-                        <constraint firstAttribute="width" secondItem="lnA-tb-Sap" secondAttribute="height" multiplier="1:1" id="lv8-l9-lJq"/>
-                    </constraints>
-                </view>
             </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="lnA-tb-Sap" firstAttribute="centerY" secondItem="KYd-D9-K5d" secondAttribute="centerY" id="1uu-Bd-bz3"/>
                 <constraint firstAttribute="trailing" secondItem="oUR-U3-uEM" secondAttribute="trailing" id="7A6-HH-MEu"/>

--- a/ALCameraViewController/Views/CropOverlay.swift
+++ b/ALCameraViewController/Views/CropOverlay.swift
@@ -18,11 +18,25 @@ internal class CropOverlay: UIView {
     var topRightCornerLines = [UIView]()
     var bottomLeftCornerLines = [UIView]()
     var bottomRightCornerLines = [UIView]()
-    
-    let cornerDepth: CGFloat = 3
-    let cornerWidth: CGFloat = 20
+
+    var cornerButtons = [UIButton]()
+
+    let cornerLineDepth: CGFloat = 3
+    let cornerLineWidth: CGFloat = 22.5
+    var cornerButtonWidth: CGFloat {
+        return self.cornerLineWidth * 2
+    }
+
     let lineWidth: CGFloat = 1
-    
+
+    let outterGapRatio: CGFloat = 1/3
+    var outterGap: CGFloat {
+        return self.cornerButtonWidth * self.outterGapRatio
+    }
+
+    var isResizable: Bool = false
+    var minimumSize: CGSize = CGSize.zero
+
     internal override init(frame: CGRect) {
         super.init(frame: frame)
         createLines()
@@ -40,16 +54,16 @@ internal class CropOverlay: UIView {
             var lineFrame: CGRect
             switch (i) {
             case 0:
-                lineFrame = CGRect(x: 0, y: 0, width: bounds.width, height: lineWidth)
+                lineFrame = CGRect(x: outterGap, y: outterGap, width: bounds.width - outterGap * 2, height: lineWidth)
                 break
             case 1:
-                lineFrame = CGRect(x: bounds.width - lineWidth, y: 0, width: lineWidth, height: bounds.height)
+                lineFrame = CGRect(x: bounds.width - lineWidth - outterGap, y: outterGap, width: lineWidth, height: bounds.height - outterGap * 2)
                 break
             case 2:
-                lineFrame = CGRect(x: 0, y: bounds.height - lineWidth, width: bounds.width, height: lineWidth)
+                lineFrame = CGRect(x: outterGap, y: bounds.height - lineWidth - outterGap, width: bounds.width - outterGap * 2, height: lineWidth)
                 break
             case 3:
-                lineFrame = CGRect(x: 0, y: 0, width: lineWidth, height: bounds.height)
+                lineFrame = CGRect(x: outterGap, y: outterGap, width: lineWidth, height: bounds.height - outterGap * 2)
                 break
             default:
                 lineFrame = CGRect.zero
@@ -62,51 +76,58 @@ internal class CropOverlay: UIView {
         let corners = [topLeftCornerLines, topRightCornerLines, bottomLeftCornerLines, bottomRightCornerLines]
         for i in 0..<corners.count {
             let corner = corners[i]
-            var horizontalFrame: CGRect
-            var verticalFrame: CGRect
-            
+			
+			var horizontalFrame: CGRect
+			var verticalFrame: CGRect
+			var buttonFrame: CGRect
+			let buttonSize = CGSize(width: cornerButtonWidth, height: cornerButtonWidth)
+			
             switch (i) {
-            case 0:
-                verticalFrame = CGRect(x: -cornerDepth, y:  -cornerDepth, width:  cornerDepth, height:  cornerWidth)
-                horizontalFrame = CGRect(x: -cornerDepth, y:  -cornerDepth, width:  cornerWidth, height:  cornerDepth)
-                break
-            case 1:
-                verticalFrame = CGRect(x: bounds.width, y:  -cornerDepth, width:  cornerDepth, height:  cornerWidth)
-                horizontalFrame = CGRect(x: bounds.width + cornerDepth - cornerWidth, y:  -cornerDepth, width:  cornerWidth, height:  cornerDepth)
-                break
-            case 2:
-                verticalFrame = CGRect(x: -cornerDepth, y:  bounds.height + cornerDepth - cornerWidth, width:  cornerDepth, height:  cornerWidth)
-                horizontalFrame = CGRect(x: -cornerDepth, y:  bounds.height, width:  cornerWidth, height:  cornerDepth)
-                break
-            case 3:
-                verticalFrame = CGRect(x: bounds.width, y:  bounds.height + cornerDepth - cornerWidth, width:  cornerDepth, height:  cornerWidth)
-                horizontalFrame = CGRect(x: bounds.width + cornerDepth - cornerWidth, y:  bounds.height, width:  cornerWidth, height:  cornerDepth)
-                break
+			case 0:	// Top Left
+				verticalFrame = CGRect(x: outterGap, y: outterGap, width: cornerLineDepth, height: cornerLineWidth)
+				horizontalFrame = CGRect(x: outterGap, y: outterGap, width: cornerLineWidth, height: cornerLineDepth)
+				buttonFrame = CGRect(origin: CGPoint(x: 0, y: 0), size: buttonSize)
+			case 1:	// Top Right
+				verticalFrame = CGRect(x: bounds.width - cornerLineDepth - outterGap, y: outterGap, width: cornerLineDepth, height: cornerLineWidth)
+				horizontalFrame = CGRect(x: bounds.width - cornerLineWidth - outterGap, y: outterGap, width: cornerLineWidth, height: cornerLineDepth)
+				buttonFrame = CGRect(origin: CGPoint(x: bounds.width - cornerButtonWidth, y: 0), size: buttonSize)
+			case 2:	// Bottom Left
+				verticalFrame = CGRect(x: outterGap, y:  bounds.height - cornerLineWidth - outterGap, width: cornerLineDepth, height: cornerLineWidth)
+				horizontalFrame = CGRect(x: outterGap, y:  bounds.height - cornerLineDepth - outterGap, width: cornerLineWidth, height: cornerLineDepth)
+				buttonFrame = CGRect(origin: CGPoint(x: 0, y: bounds.height - cornerButtonWidth), size: buttonSize)
+			case 3:	// Bottom Right
+				verticalFrame = CGRect(x: bounds.width - cornerLineDepth - outterGap, y: bounds.height - cornerLineWidth - outterGap, width: cornerLineDepth, height: cornerLineWidth)
+				horizontalFrame = CGRect(x: bounds.width - cornerLineWidth - outterGap, y: bounds.height - cornerLineDepth - outterGap, width: cornerLineWidth, height: cornerLineDepth)
+				buttonFrame = CGRect(origin: CGPoint(x: bounds.width - cornerButtonWidth, y: bounds.height - cornerButtonWidth), size: buttonSize)
+
             default:
                 verticalFrame = CGRect.zero
                 horizontalFrame = CGRect.zero
-                break
+				buttonFrame = CGRect.zero
             }
-            
+			
             corner[0].frame = verticalFrame
             corner[1].frame = horizontalFrame
+			cornerButtons[i].frame = buttonFrame
         }
-        
-        let lineThickness = lineWidth / UIScreen.main.scale
-        let padding = (bounds.height - (lineThickness * CGFloat(horizontalLines.count))) / CGFloat(horizontalLines.count + 1)
-        
+		
+		let lineThickness = lineWidth / UIScreen.main.scale
+		let vPadding = (bounds.height - outterGap * 2 - (lineThickness * CGFloat(horizontalLines.count))) / CGFloat(horizontalLines.count + 1)
+		let hPadding = (bounds.width - outterGap * 2 - (lineThickness * CGFloat(verticalLines.count))) / CGFloat(verticalLines.count + 1)
+		
         for i in 0..<horizontalLines.count {
             let hLine = horizontalLines[i]
             let vLine = verticalLines[i]
-            
-            let spacing = (padding * CGFloat(i + 1)) + (lineThickness * CGFloat(i))
-            
-            hLine.frame = CGRect(x: 0, y: spacing, width: bounds.width, height:  lineThickness)
-            vLine.frame = CGRect(x: spacing, y: 0, width: lineThickness, height: bounds.height)
+			
+			let vSpacing = (vPadding * CGFloat(i + 1)) + (lineThickness * CGFloat(i))
+			let hSpacing = (hPadding * CGFloat(i + 1)) + (lineThickness * CGFloat(i))
+			
+			hLine.frame = CGRect(x: outterGap, y: vSpacing + outterGap, width: bounds.width - outterGap * 2, height:  lineThickness)
+			vLine.frame = CGRect(x: hSpacing + outterGap, y: outterGap, width: lineThickness, height: bounds.height - outterGap * 2)
         }
-        
+		
     }
-    
+	
     func createLines() {
         
         outerLines = [createLine(), createLine(), createLine(), createLine()]
@@ -118,7 +139,10 @@ internal class CropOverlay: UIView {
         bottomLeftCornerLines = [createLine(), createLine()]
         bottomRightCornerLines = [createLine(), createLine()]
         
-        isUserInteractionEnabled = false
+		cornerButtons = [createButton(), createButton(), createButton(), createButton()]
+		
+		let dragGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(moveCropOverlay))
+		addGestureRecognizer(dragGestureRecognizer)
     }
     
     func createLine() -> UIView {
@@ -127,4 +151,59 @@ internal class CropOverlay: UIView {
         addSubview(line)
         return line
     }
+	
+	func createButton() -> UIButton {
+		let button = UIButton()
+		button.backgroundColor = UIColor.clear
+		
+		let dragGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(moveCropOverlay))
+		button.addGestureRecognizer(dragGestureRecognizer)
+		
+//		// DEBUG
+//		button.backgroundColor = .yellow
+//		button.alpha = 0.2
+
+		addSubview(button)
+		return button
+	}
+	
+	func moveCropOverlay(gestureRecognizer: UIPanGestureRecognizer) {
+		if let button = gestureRecognizer.view as? UIButton {
+            guard isResizable else {
+                return
+            }
+
+			if gestureRecognizer.state == .began || gestureRecognizer.state == .changed {
+				let translation = gestureRecognizer.translation(in: self)
+				
+				var newFrame: CGRect
+				
+				switch button {
+				case cornerButtons[0]:	// Top Left
+                    newFrame = CGRect(x: frame.origin.x + translation.x, y: frame.origin.y + translation.y, width: frame.size.width - translation.x, height: frame.size.height - translation.y)
+				case cornerButtons[1]:	// Top Right
+					newFrame = CGRect(x: frame.origin.x, y: frame.origin.y + translation.y, width: frame.size.width + translation.x, height: frame.size.height - translation.y)
+				case cornerButtons[2]:	// Bottom Left
+					newFrame = CGRect(x: frame.origin.x + translation.x, y: frame.origin.y, width: frame.size.width - translation.x, height: frame.size.height + translation.y)
+				case cornerButtons[3]:	// Bottom Right
+					newFrame = CGRect(x: frame.origin.x, y: frame.origin.y, width: frame.size.width + translation.x, height: frame.size.height + translation.y)
+				default:
+					newFrame = CGRect.zero
+				}
+
+                let minimumFrame = CGRect(x: newFrame.origin.x, y: newFrame.origin.y, width: max(newFrame.size.width, minimumSize.width + 2 * outterGap), height: max(newFrame.size.height, minimumSize.height + 2 * outterGap))
+				frame = minimumFrame
+				layoutSubviews()
+
+				gestureRecognizer.setTranslation(CGPoint.zero, in: self)
+			}
+		} else {
+			if gestureRecognizer.state == .began || gestureRecognizer.state == .changed {
+				let translation = gestureRecognizer.translation(in: self)
+				
+				gestureRecognizer.view!.center = CGPoint(x: gestureRecognizer.view!.center.x + translation.x, y: gestureRecognizer.view!.center.y + translation.y)
+				gestureRecognizer.setTranslation(CGPoint(x: 0, y: 0), in: self)
+			}
+		}
+	}
 }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -10,17 +10,27 @@ import UIKit
 
 class ViewController: UIViewController {
 
-    var croppingEnabled: Bool = false
     var libraryEnabled: Bool = true
-    
-    @IBOutlet weak var imageView: UIImageView!
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    var croppingEnabled: Bool = false
+    var allowResizing: Bool = true
+    var minimumSize: CGSize = CGSize(width: 60, height: 60)
+
+    var croppingParameters: CroppingParameters {
+        return CroppingParameters(isEnabled: croppingEnabled, allowResizing: allowResizing, minimumSize: minimumSize)
     }
     
-    @IBAction func openCamera(_ sender: AnyObject) {
-        let cameraViewController = CameraViewController(croppingEnabled: croppingEnabled, allowsLibraryAccess: libraryEnabled) { [weak self] image, asset in
+    @IBOutlet weak var imageView: UIImageView!
+    @IBOutlet weak var croppingParametersView: UIView!
+    @IBOutlet weak var minimumSizeLabel: UILabel!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+		
+		self.imageView.contentMode = .scaleAspectFit
+    }
+    
+    @IBAction func openCamera(_ sender: Any) {
+        let cameraViewController = CameraViewController(croppingParameters: croppingParameters, allowsLibraryAccess: libraryEnabled) { [weak self] image, asset in
             self?.imageView.image = image
             self?.dismiss(animated: true, completion: nil)
         }
@@ -28,8 +38,8 @@ class ViewController: UIViewController {
         present(cameraViewController, animated: true, completion: nil)
     }
     
-    @IBAction func openLibrary(_ sender: AnyObject) {
-        let libraryViewController = CameraViewController.imagePickerViewController(croppingEnabled: croppingEnabled) { [weak self] image, asset in
+    @IBAction func openLibrary(_ sender: Any) {
+        let libraryViewController = CameraViewController.imagePickerViewController(croppingParameters: croppingParameters) { [weak self] image, asset in
             self?.imageView.image = image
             self?.dismiss(animated: true, completion: nil)
         }
@@ -37,12 +47,36 @@ class ViewController: UIViewController {
         present(libraryViewController, animated: true, completion: nil)
     }
     
-    @IBAction func libraryChanged(_ sender: AnyObject) {
+    @IBAction func libraryChanged(_ sender: Any) {
         libraryEnabled = !libraryEnabled
     }
     
-    @IBAction func croppingChanged(_ sender: AnyObject) {
-        croppingEnabled = !croppingEnabled
+    @IBAction func croppingChanged(_ sender: Any) {
+        guard let switchButton = sender as? UISwitch else {
+            return
+        }
+
+        croppingEnabled = switchButton.isOn
+        croppingParametersView.isHidden = !switchButton.isOn
     }
+
+    @IBAction func resizingChanged(_ sender: Any) {
+        guard let switchButton = sender as? UISwitch else {
+            return
+        }
+
+        allowResizing = switchButton.isOn
+    }
+
+    @IBAction func minimumSizeChanged(_ sender: Any) {
+        guard let sliderButton = sender as? UISlider else {
+            return
+        }
+
+        let newValue = sliderButton.value
+        minimumSize = CGSize(width: CGFloat(newValue), height: CGFloat(newValue))
+        minimumSizeLabel.text = "Minimum size: \(newValue.rounded())"
+    }
+
 }
 

--- a/Example/ViewController.xib
+++ b/Example/ViewController.xib
@@ -1,26 +1,35 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_0" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ViewController" customModule="ALCameraViewController" customModuleProvider="target">
             <connections>
+                <outlet property="croppingParametersView" destination="aZk-39-lei" id="iih-He-zYC"/>
                 <outlet property="imageView" destination="I4G-in-XtY" id="U1I-c7-fHk"/>
+                <outlet property="minimumSizeLabel" destination="DXi-q2-e5s" id="NxY-Mc-zZv"/>
                 <outlet property="view" destination="iN0-l3-epB" id="NQI-AD-Uhb"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
             <subviews>
-                <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="I4G-in-XtY"/>
+                <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="I4G-in-XtY">
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                </imageView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QHP-Db-zQM">
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="100"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cgD-PF-WNE">
+                            <rect key="frame" x="70" y="28" width="41" height="29"/>
                             <fontDescription key="fontDescription" name="AppleSDGothicNeo-Regular" family="Apple SD Gothic Neo" pointSize="14"/>
                             <state key="normal" title="Library">
                                 <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -30,11 +39,13 @@
                             </connections>
                         </button>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Cropping" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3e8-yb-h3L">
+                            <rect key="frame" x="258" y="65" width="53.5" height="17"/>
                             <fontDescription key="fontDescription" name="AppleSDGothicNeo-Regular" family="Apple SD Gothic Neo" pointSize="14"/>
                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YHP-W6-S2W">
+                            <rect key="frame" x="15" y="28" width="45" height="29"/>
                             <fontDescription key="fontDescription" name="AppleSDGothicNeo-Regular" family="Apple SD Gothic Neo" pointSize="14"/>
                             <state key="normal" title="Camera">
                                 <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -44,16 +55,19 @@
                             </connections>
                         </button>
                         <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="kvv-7d-Re7">
+                            <rect key="frame" x="260.5" y="28" width="51" height="31"/>
                             <connections>
                                 <action selector="croppingChanged:" destination="-1" eventType="valueChanged" id="fjU-Hs-bwf"/>
                             </connections>
                         </switch>
                         <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JPj-mG-Hu1">
+                            <rect key="frame" x="176" y="28" width="51" height="31"/>
                             <connections>
                                 <action selector="libraryChanged:" destination="-1" eventType="valueChanged" id="Bt6-HK-b05"/>
                             </connections>
                         </switch>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Library Access" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VFc-CF-Vtc">
+                            <rect key="frame" x="158" y="65" width="84.5" height="17"/>
                             <fontDescription key="fontDescription" name="AppleSDGothicNeo-Regular" family="Apple SD Gothic Neo" pointSize="14"/>
                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
@@ -76,15 +90,63 @@
                         <constraint firstItem="YHP-W6-S2W" firstAttribute="top" secondItem="QHP-Db-zQM" secondAttribute="top" constant="28" id="xrT-P5-K1h"/>
                     </constraints>
                 </view>
+                <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aZk-39-lei">
+                    <rect key="frame" x="0.0" y="468" width="320" height="100"/>
+                    <subviews>
+                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="k5h-ry-m8S">
+                            <rect key="frame" x="24" y="28" width="51" height="31"/>
+                            <connections>
+                                <action selector="libraryChanged:" destination="-1" eventType="valueChanged" id="LKB-0U-NRn"/>
+                                <action selector="resizingChanged:" destination="-1" eventType="valueChanged" id="veN-be-OGb"/>
+                            </connections>
+                        </switch>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Allow resizing" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="In7-Or-H5s">
+                            <rect key="frame" x="8" y="65" width="81.5" height="17"/>
+                            <fontDescription key="fontDescription" name="AppleSDGothicNeo-Regular" family="Apple SD Gothic Neo" pointSize="14"/>
+                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="60" minValue="0.0" maxValue="200" translatesAutoresizingMaskIntoConstraints="NO" id="wMe-QX-l9A">
+                            <rect key="frame" x="160" y="28" width="154" height="31"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="150" id="sUi-Og-5Hl"/>
+                            </constraints>
+                            <connections>
+                                <action selector="minimumSizeChanged:" destination="-1" eventType="valueChanged" id="Ig1-7S-e3e"/>
+                            </connections>
+                        </slider>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Minimum size: 60" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DXi-q2-e5s">
+                            <rect key="frame" x="185" y="64" width="105.5" height="17"/>
+                            <fontDescription key="fontDescription" name="AppleSDGothicNeo-Regular" family="Apple SD Gothic Neo" pointSize="14"/>
+                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
+                    <constraints>
+                        <constraint firstItem="DXi-q2-e5s" firstAttribute="top" secondItem="wMe-QX-l9A" secondAttribute="bottom" constant="6" id="JKt-OZ-OfS"/>
+                        <constraint firstAttribute="height" constant="100" id="MTP-Zi-Sp6"/>
+                        <constraint firstItem="wMe-QX-l9A" firstAttribute="top" secondItem="k5h-ry-m8S" secondAttribute="top" id="Oi9-A3-OeO"/>
+                        <constraint firstItem="k5h-ry-m8S" firstAttribute="top" secondItem="aZk-39-lei" secondAttribute="top" constant="28" id="YVP-87-gmz"/>
+                        <constraint firstAttribute="trailing" secondItem="wMe-QX-l9A" secondAttribute="trailing" constant="8" id="oW4-sC-slS"/>
+                        <constraint firstItem="In7-Or-H5s" firstAttribute="top" secondItem="k5h-ry-m8S" secondAttribute="bottom" constant="6" id="op5-Pa-JNB"/>
+                        <constraint firstItem="DXi-q2-e5s" firstAttribute="centerX" secondItem="wMe-QX-l9A" secondAttribute="centerX" id="usT-6x-EtL"/>
+                        <constraint firstItem="In7-Or-H5s" firstAttribute="leading" secondItem="aZk-39-lei" secondAttribute="leading" constant="8" id="wRs-Qw-Sic"/>
+                        <constraint firstItem="k5h-ry-m8S" firstAttribute="centerX" secondItem="In7-Or-H5s" secondAttribute="centerX" id="z4S-xt-ZNI"/>
+                    </constraints>
+                </view>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="I4G-in-XtY" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="3AX-fE-Hk9"/>
                 <constraint firstAttribute="bottom" secondItem="I4G-in-XtY" secondAttribute="bottom" id="3lv-gB-kJY"/>
+                <constraint firstAttribute="trailing" secondItem="aZk-39-lei" secondAttribute="trailing" id="4zq-u4-Caf"/>
                 <constraint firstItem="QHP-Db-zQM" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="6X2-HK-7yY"/>
+                <constraint firstItem="aZk-39-lei" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="Mbt-ze-5GF"/>
                 <constraint firstAttribute="trailing" secondItem="QHP-Db-zQM" secondAttribute="trailing" id="UKI-40-dOB"/>
                 <constraint firstAttribute="trailing" secondItem="I4G-in-XtY" secondAttribute="trailing" id="YSb-RL-EaX"/>
                 <constraint firstItem="I4G-in-XtY" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="hv9-n7-2WA"/>
+                <constraint firstAttribute="bottom" secondItem="aZk-39-lei" secondAttribute="bottom" id="sdt-XQ-KKp"/>
                 <constraint firstItem="QHP-Db-zQM" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="x5W-Fe-hte"/>
             </constraints>
             <point key="canvasLocation" x="366" y="492"/>


### PR DESCRIPTION
**This PR add the resizable cropping area feature.**

Closes #15.
Update of #192.

It also:
- Removed the default Team ID.
- Changed the view order into Confirmation View in order to always be able to tap on confirm & cancel buttons.
- Added an option to disable the feature.
- Defined a minimum area to crop (@ameli90) and added an option to change it.

Left to do later on:
- Prevent user to crop outside of the image bounds.
