### PR TITLE
Allow CameraViewController to be used in a navigation stack without losing completion

### DIFF
--- a/ALCameraViewController/ViewController/CameraViewController.swift
+++ b/ALCameraViewController/ViewController/CameraViewController.swift
@@ -541,7 +541,6 @@ open class CameraViewController: UIViewController {
 	
     internal func close() {
         onCompletion?(nil, nil)
-        onCompletion = nil
     }
     
     internal func showLibrary() {
@@ -605,7 +604,6 @@ open class CameraViewController: UIViewController {
 			}
 			
 			self?.onCompletion?(image, asset)
-			self?.onCompletion = nil
 		}
 		confirmViewController.modalTransitionStyle = UIModalTransitionStyle.crossDissolve
 		present(confirmViewController, animated: true, completion: nil)
@@ -623,7 +621,6 @@ open class CameraViewController: UIViewController {
             }
 
             self?.onCompletion?(image, asset)
-            self?.onCompletion = nil
         }
         confirmViewController.modalTransitionStyle = UIModalTransitionStyle.crossDissolve
         present(confirmViewController, animated: true, completion: nil)


### PR DESCRIPTION
When the CameraViewController is on a Navigation Stack, a picture is taken, and a new ViewController is pushed on the stack, when you hit back to return to the CameraViewController, the completion no longer exists and can no longer be called, making it impossible to leave the CameraViewController. We removed clearing out the completion blocks. This should be ok and not leave retain cycles because the presenting CameraViewController has the only reference to the completion.