### PR TITLE
restart camera if photo confirmation was canceled

### DIFF
--- a/ALCameraViewController/ViewController/CameraViewController.swift
+++ b/ALCameraViewController/ViewController/CameraViewController.swift
@@ -579,6 +579,7 @@ open class CameraViewController: UIViewController {
 			}
 			
 			guard let image = image else {
+				self?.cameraView.startSession()
 				return
 			}
 			


### PR DESCRIPTION
This little PR restarts the camera session if the user has canceled the photo confirmation. 

Before there was a black screen after the cancellation and the user could only restart the camera session by pulling down the CameraViewController a little bit. In that case `viewWillAppear` was called again restarting the camera session.